### PR TITLE
Fix error on RN 0.60

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ class CollapseView extends Component {
     this.state = {
       collapse: this.props.collapse,
       animation: new Animated.Value(),
+      startpoint: null,
+      endpoint: null
     };
   }
 
@@ -56,13 +58,15 @@ class CollapseView extends Component {
 
   render() {
     const { startpoint, endpoint, animation, collapse } = this.state;
+    const height = startpoint !== null && endpoint !== null ? animation : null
+
     return (
-      <Animated.View style={{height: this.state.animation, backgroundColor:'transparent', overflow: 'hidden'}}>
+      <Animated.View style={{height, backgroundColor:'transparent', overflow: 'hidden'}}>
         <TouchableOpacity activeOpacity={1} onPress={this.collapse} onLayout={this.startpoint}>
-          {this.props.renderView(this.state.collapse)}
+          {this.props.renderView(collapse)}
         </TouchableOpacity>
         <View onLayout={this.endpoint}>
-          {this.props.renderCollapseView(this.state.collapse)}
+          {this.props.renderCollapseView(collapse)}
         </View>
       </Animated.View>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -43,14 +43,14 @@ class CollapseView extends Component {
   }
 
   startpoint = (layout) => {
-    if(!this.state.collapse) this.setState({animation: new Animated.Value(layout.nativeEvent.layout.height)});
+    if(!this.state.collapse) this.setState({animation: new Animated.Value(layout.nativeEvent.layout.height + this.state.endpoint)});
     this.setState({
       startpoint: layout.nativeEvent.layout.height
     })
   }
 
   endpoint = (layout) => {
-    if(this.state.collapse) this.setState({animation: new Animated.Value(layout.nativeEvent.layout.height)});
+    if(this.state.collapse) this.setState({animation: new Animated.Value(layout.nativeEvent.layout.height + this.state.startpoint)});
     this.setState({
       endpoint: layout.nativeEvent.layout.height,
     })


### PR DESCRIPTION
When trying to render a `CollapseView` I get this error:

`Invariant Violation: [659,"RCTView",311,{"height":"<<NaN>>","backgroundColor":0,"overflow":"hidden"}] is not usable as a native method argument`

This is caused by giving an uninitiated `Animated.Value` as the component's height. I fixed it by setting the height as `null` until header and content layouts are measured.